### PR TITLE
Update legacy mongo extension to 1.6.16

### DIFF
--- a/bin/compile-extension-mongo
+++ b/bin/compile-extension-mongo
@@ -8,7 +8,7 @@ travis_time_start
 if [[ ! $VERSION =~ ^7 && ! $VERSION =~ ^master$ ]]; then
 	git clone https://github.com/mongodb/mongo-php-driver-legacy.git
 	pushd mongo-php-driver-legacy
-	git checkout 1.6.12
+	git checkout 1.6.16
 	phpize
 	./configure && make && make install
 	popd


### PR DESCRIPTION
1.6.16 is the latest release in [PECL](https://pecl.php.net/package/mongo).