### PR TITLE
Use mongodb master branch for PHP master and snapshot

### DIFF
--- a/bin/compile-extension-mongodb
+++ b/bin/compile-extension-mongodb
@@ -5,7 +5,7 @@ source $(dirname $0)/compile-extensions-common
 
 travis_time_start
 
-if [[ $VERSION =~ ^7 || $VERSION =~ ^master$ ]]; then
+if [[ $VERSION =~ ^master$ || $VERSION =~ snapshot$ ]]; then
 	git clone https://github.com/mongodb/mongo-php-driver.git
 	pushd mongo-php-driver
 	git submodule update --init


### PR DESCRIPTION
Based on previous discussion in https://github.com/travis-ci/php-src-builder/pull/5#discussion_r138078544.

PHP 7 has been supported in stable PECL releases since mongodb-1.1.1, so there is no need to build the master branch for all PHP 7.x environments. This will also ensure that PHP 7.x environments use a stable version of the extension.

I added "snapshot" after noticing it was used in [`compile-extension-redis`](https://github.com/travis-ci/php-src-builder/blob/default/bin/compile-extension-redis) and learning it's purpose from https://github.com/travis-ci/travis-ci/issues/7268 (nightly builds of older release branches).