### PR TITLE
Remove unbalanced pushd

### DIFF
--- a/bin/compile-extension-memcache
+++ b/bin/compile-extension-memcache
@@ -6,7 +6,6 @@ source $(dirname $0)/compile-extensions-common
 travis_time_start
 
 if [[ ! $VERSION =~ ^7 && ! $VERSION =~ ^master$ ]]; then
-	pushd /tmp
 	pecl download memcache-beta
 	tar zxvf memcache*.tgz && pushd memcache*
 	make clean || true


### PR DESCRIPTION
popd is only called once, so this might leave the build process in the /tmp directory.

Other compile scripts don't appear to `pushd /tmp` before downloading a package or cloning a repository, so the push likely wasn't necessary.