### PR TITLE
mongodb-1.3.0+ does not support PHP 5.4

### DIFF
--- a/bin/compile-extension-mongodb
+++ b/bin/compile-extension-mongodb
@@ -14,6 +14,8 @@ if [[ $VERSION =~ ^master$ || $VERSION =~ snapshot$ ]]; then
 	make  all
 	make install
 	popd
+elif [[ $VERSION =~ ^5\.4 ]]; then
+	pecl_install mongodb-1.2.11
 else
 	pecl_install mongodb
 fi


### PR DESCRIPTION
PECL is unable to resolve a compatible package release for the given PHP version, so we need to specify an exact version to install.

Related to discussion in https://github.com/travis-ci/travis-ci/issues/8399#issuecomment-331746491.