### PR TITLE
Let default config be easily overridable

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -47,7 +47,7 @@ popd
 
 mkdir -p "${INSTALL_DEST}/${VERSION}/etc/conf.d"
 
-cat > "${INSTALL_DEST}/${VERSION}/etc/conf.d/travis.ini" <<EOF
+cat > "${INSTALL_DEST}/${VERSION}/etc/conf.d/000_travis.ini" <<EOF
 memory_limit = 1G
 date.timezone = "UTC"
 phar.readonly = 0


### PR DESCRIPTION
If a configuration file is added with `phpenv config-add custum.ini`,
and the config tries to override a default value of `travis.ini`, it
will lose, as `travis.ini` is read later if the file starts with a
letter earlier in the alphabet than t.

This PR make the default easily overridable.

See https://travis-ci.org/joepvd/travis-experiment/builds/281200514 for
details.