### PR TITLE
Use php-memcached 3.0.4 for PHP 7.x

### DIFF
--- a/bin/compile-extension-memcached
+++ b/bin/compile-extension-memcached
@@ -14,8 +14,9 @@ popd
 popd
 
 if [[ $VERSION =~ ^7 || $VERSION =~ ^master$ ]]; then
-	git clone https://github.com/php-memcached-dev/php-memcached.git --branch php7
-	pushd php-memcached
+	pecl download memcached-3.0.4
+	tar zxvf memcached*.tgz && pushd memcached*
+	make clean || true
 else
 	pecl download memcached-2.2.0
 	tar zxvf memcached*.tgz && pushd memcached*


### PR DESCRIPTION
The upstream php7 branch is now defunct as it was merged to master and released
as 3.0.0 in January 2017. As of php-memcached 3.0.4, PHP 7.0 - 7.1 - 7.2 are supported.