### PR TITLE
[WIP] Add libsodium with Argon2i hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
 - popd
 - if [[ $RELEASE = trusty ]]; then unset ICU_RELEASE; fi # disable ICU installation for Trusty; see https://github.com/travis-ci/travis-ci/issues/3616#issuecomment-286302387
 - ./bin/install-icu
+- ./bin/install-password-argon2
 - cp default_configure_options.$RELEASE $HOME/.php-build/share/php-build/default_configure_options
 - |
   if [[ $VERSION = master ]]; then
@@ -104,4 +105,3 @@ addons:
       - libzip-dev
       - libgmp3-dev
       - expect
-

--- a/bin/install-password-argon2
+++ b/bin/install-password-argon2
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -o xtrace
+set -o errexit
+
+# If PHP < 7.2, exit
+if [[ $VERSION =~ ^master$ ]]; then
+	echo 'unknown PHP version; skip password-argon2 steps'
+	exit 0
+elif [ "$(printf "7.2\n$VERSION" | sort -V | head -n1)" != "7.2" ]; then
+	echo 'PHP < 7.2; skip password-argon2 steps'
+	exit 0
+fi
+
+LIBSODIUM_INSTALL_DIR=$HOME/.phpenv/versions/$VERSION
+
+git clone -b stable https://github.com/jedisct1/libsodium.git
+
+# compile
+pushd libsodium
+./configure --prefix=$LIBSODIUM_INSTALL_DIR
+make check
+make install
+popd
+
+# add the option in default_configure_options
+echo "--with-password-argon2=$LIBSODIUM_INSTALL_DIR" >> $TRAVIS_BUILD_DIR/default_configure_options.${RELEASE}


### PR DESCRIPTION
As reported in travis-ci/travis-ci#8863, PHP 7.2 is missing libsodium and Argon2i support; this is wrong because by default PHP 7.2 comes with that, so a lot of builds are failing or required to use a long workaround and install it manually.

This fork isn't mine, but it should work to enable it from PHP 7.2 and forward.