### PR TITLE
Fix libsodium recipe + build PHP with Argon2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ install:
 - if [[ $RELEASE != precise ]]; then unset ICU_RELEASE; fi # disable ICU installation for Trusty; see https://github.com/travis-ci/travis-ci/issues/3616#issuecomment-286302387
 - ./bin/install-icu
 - ./bin/install-libsodium
+- ./bin/install-password-argon2
 - |
   if [[ -f default_configure_options.$RELEASE-${VERSION%*.*} ]]; then
     cp default_configure_options.$RELEASE-${VERSION%*.*} $HOME/.php-build/share/php-build/default_configure_options

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
 - popd
 - if [[ $RELEASE != precise ]]; then unset ICU_RELEASE; fi # disable ICU installation for Trusty; see https://github.com/travis-ci/travis-ci/issues/3616#issuecomment-286302387
 - ./bin/install-icu
-- ./bin/install-password-argon2
+- ./bin/install-libsodium
 - |
   if [[ -f default_configure_options.$RELEASE-${VERSION%*.*} ]]; then
     cp default_configure_options.$RELEASE-${VERSION%*.*} $HOME/.php-build/share/php-build/default_configure_options

--- a/bin/install-libsodium
+++ b/bin/install-libsodium
@@ -5,10 +5,10 @@ set -o errexit
 
 # If PHP < 7.2, exit
 if [[ $VERSION =~ ^master$ ]]; then
-	echo 'unknown PHP version; skip password-argon2 steps'
+	echo 'unknown PHP version; skip libsodium steps'
 	exit 0
 elif [[ "$(printf "7.2\n$VERSION" | sort -V | head -n1)" < "7.2" ]]; then
-	echo 'PHP < 7.2; skip password-argon2 steps'
+	echo 'PHP < 7.2; skip libsodium steps'
 	exit 0
 fi
 
@@ -24,4 +24,4 @@ make install
 popd
 
 # add the option in default_configure_options
-echo "--with-password-argon2=$LIBSODIUM_INSTALL_DIR" >> $TRAVIS_BUILD_DIR/default_configure_options.${RELEASE}
+echo "--with-sodium=$LIBSODIUM_INSTALL_DIR" >> $TRAVIS_BUILD_DIR/default_configure_options.${RELEASE}

--- a/bin/install-libsodium
+++ b/bin/install-libsodium
@@ -4,10 +4,7 @@ set -o xtrace
 set -o errexit
 
 # If PHP < 7.2, exit
-if [[ $VERSION =~ ^master$ ]]; then
-	echo 'unknown PHP version; skip libsodium steps'
-	exit 0
-elif [[ "$(printf "7.2\n$VERSION" | sort -V | head -n1)" < "7.2" ]]; then
+if [[ ! $VERSION =~ ^master$ ]] && [[ "$(printf "7.2\n$VERSION" | sort -V | head -n1)" < "7.2" ]]; then
 	echo 'PHP < 7.2; skip libsodium steps'
 	exit 0
 fi

--- a/bin/install-password-argon2
+++ b/bin/install-password-argon2
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -o xtrace
+set -o errexit
+
+# If PHP < 7.2, exit
+if [[ ! $VERSION =~ ^master$ ]] && [[ "$(printf "7.2\n$VERSION" | sort -V | head -n1)" < "7.2" ]]; then
+	echo 'PHP < 7.2; skip password-argon2 steps'
+	exit 0
+fi
+
+LIBARGON2_INSTALL_DIR=$HOME/.phpenv/versions/$VERSION
+
+git clone -b 20171227 https://github.com/P-H-C/phc-winner-argon2.git libargon2
+
+# compile
+pushd libargon2
+make test
+make install PREFIX=$LIBARGON2_INSTALL_DIR
+popd
+
+# add the option in default_configure_options
+echo "--with-password-argon2=$LIBARGON2_INSTALL_DIR" >> $TRAVIS_BUILD_DIR/default_configure_options.${RELEASE}


### PR DESCRIPTION
* Fix libsodium recipe name and PHP configure option
* Add recipe for Argon2 - compilation and PHP configure option

Fixes https://github.com/travis-ci/php-src-builder/pull/20#issuecomment-426702532.

This [successfully built](https://travis-ci.org/Majkl578/travis-ci-php-src-builder/builds/436789583) on Xenial with PHP 7.3, but Trusty and Precise still fail due to the outdated libzip.