### PR TITLE
Manually build libzip for PHP 7.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ install:
 - if [[ $RELEASE != precise ]]; then unset ICU_RELEASE; fi # disable ICU installation for Trusty; see https://github.com/travis-ci/travis-ci/issues/3616#issuecomment-286302387
 - ./bin/install-icu
 - ./bin/install-libsodium
+- ./bin/install-password-argon2
 - |
   if [[ -f default_configure_options.$RELEASE-${VERSION%*.*} ]]; then
     cp default_configure_options.$RELEASE-${VERSION%*.*} $HOME/.php-build/share/php-build/default_configure_options

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
 - popd
 - if [[ $RELEASE != precise ]]; then unset ICU_RELEASE; fi # disable ICU installation for Trusty; see https://github.com/travis-ci/travis-ci/issues/3616#issuecomment-286302387
 - ./bin/install-icu
-- ./bin/install-password-argon2
+- ./bin/install-libsodium
 - |
   if [[ -f default_configure_options.$RELEASE-${VERSION%*.*} ]]; then
     cp default_configure_options.$RELEASE-${VERSION%*.*} $HOME/.php-build/share/php-build/default_configure_options

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ install:
 - popd
 - if [[ $RELEASE != precise ]]; then unset ICU_RELEASE; fi # disable ICU installation for Trusty; see https://github.com/travis-ci/travis-ci/issues/3616#issuecomment-286302387
 - ./bin/install-icu
+- ./bin/install-libzip
 - ./bin/install-libsodium
 - ./bin/install-password-argon2
 - |
@@ -68,10 +69,6 @@ install:
     cp default_configure_options.$RELEASE-${VERSION%*.*} $HOME/.php-build/share/php-build/default_configure_options
   else
     cp default_configure_options.$RELEASE $HOME/.php-build/share/php-build/default_configure_options
-  fi
-- |
-  if [[ $VERSION = master ]]; then
-    echo "--without-libzip" >> $HOME/.php-build/share/php-build/default_configure_options
   fi
 - | # disable xdebug on master
   if [[ $VERSION = master && $RELEASE != xenial ]]; then

--- a/bin/install-libsodium
+++ b/bin/install-libsodium
@@ -5,10 +5,10 @@ set -o errexit
 
 # If PHP < 7.2, exit
 if [[ $VERSION =~ ^master$ ]]; then
-	echo 'unknown PHP version; skip password-argon2 steps'
+	echo 'unknown PHP version; skip libsodium steps'
 	exit 0
 elif [[ "$(printf "7.2\n$VERSION" | sort -V | head -n1)" < "7.2" ]]; then
-	echo 'PHP < 7.2; skip password-argon2 steps'
+	echo 'PHP < 7.2; skip libsodium steps'
 	exit 0
 fi
 
@@ -24,4 +24,4 @@ make install
 popd
 
 # add the option in default_configure_options
-echo "--with-password-argon2=$LIBSODIUM_INSTALL_DIR" >> $TRAVIS_BUILD_DIR/default_configure_options.${RELEASE}
+echo "--with-sodium=$LIBSODIUM_INSTALL_DIR" >> $TRAVIS_BUILD_DIR/default_configure_options.${RELEASE}

--- a/bin/install-libsodium
+++ b/bin/install-libsodium
@@ -4,10 +4,7 @@ set -o xtrace
 set -o errexit
 
 # If PHP < 7.2, exit
-if [[ $VERSION =~ ^master$ ]]; then
-	echo 'unknown PHP version; skip libsodium steps'
-	exit 0
-elif [[ "$(printf "7.2\n$VERSION" | sort -V | head -n1)" < "7.2" ]]; then
+if [[ ! $VERSION =~ ^master$ ]] && [[ "$(printf "7.2\n$VERSION" | sort -V | head -n1)" < "7.2" ]]; then
 	echo 'PHP < 7.2; skip libsodium steps'
 	exit 0
 fi

--- a/bin/install-libzip
+++ b/bin/install-libzip
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o xtrace
+set -o errexit
+
+# If PHP < 7.3, exit
+if [[ ! $VERSION =~ ^master$ ]] && [[ "$(printf "7.3\n$VERSION" | sort -V | head -n1)" < "7.3" ]]; then
+	echo 'PHP < 7.3; skip libzip steps'
+	exit 0
+fi
+
+LIBZIP_INSTALL_DIR=$HOME/.phpenv/versions/$VERSION
+
+# get up-to-date cmake
+mkdir cmake
+pushd cmake
+wget -O - https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.tar.gz | tar -xz --strip-components=1
+popd
+
+# compile libzip
+git clone -b rel-1-5-1 https://github.com/nih-at/libzip.git
+pushd libzip
+../cmake/bin/cmake -DCMAKE_INSTALL_PREFIX=$LIBZIP_INSTALL_DIR .
+make
+make install
+popd
+
+# add the option in default_configure_options
+echo "--with-libzip=$LIBZIP_INSTALL_DIR" >> $TRAVIS_BUILD_DIR/default_configure_options.${RELEASE}

--- a/bin/install-password-argon2
+++ b/bin/install-password-argon2
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -o xtrace
+set -o errexit
+
+# If PHP < 7.2, exit
+if [[ ! $VERSION =~ ^master$ ]] && [[ "$(printf "7.2\n$VERSION" | sort -V | head -n1)" < "7.2" ]]; then
+	echo 'PHP < 7.2; skip password-argon2 steps'
+	exit 0
+fi
+
+LIBARGON2_INSTALL_DIR=$HOME/.phpenv/versions/$VERSION
+
+git clone -b 20171227 https://github.com/P-H-C/phc-winner-argon2.git libargon2
+
+# compile
+pushd libargon2
+make test
+make install PREFIX=$LIBARGON2_INSTALL_DIR
+popd
+
+# add the option in default_configure_options
+echo "--with-password-argon2=$LIBARGON2_INSTALL_DIR" >> $TRAVIS_BUILD_DIR/default_configure_options.${RELEASE}


### PR DESCRIPTION
_Includes changes from #22 to avoid build failures and conflicts._

The only relevant commit is the last one: 3441210

For PHP 7.3+, build and install latest libzip manually, then build against this local version instead of the system one (which is either outdated on Trusty and Precise or missing at runtime on Xenial).

cc @cmb69