### PR TITLE
Add NTS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
 
 env:
   global:
-  - VERSION=master ALIAS=nightly
+  - VERSION=master ALIAS=nightly ZTS=enable
   - ICU_RELEASE=59.1
   - ICU_INSTALL_DIR=$HOME/.phpenv/versions/$VERSION
   - PATH="$HOME/.phpenv/bin:$HOME/.php-build/bin:$PATH"
@@ -69,6 +69,10 @@ install:
     cp default_configure_options.$RELEASE-${VERSION%*.*} $HOME/.php-build/share/php-build/default_configure_options
   else
     cp default_configure_options.$RELEASE $HOME/.php-build/share/php-build/default_configure_options
+  fi
+- | # support non-thread-safe builds
+  if [[ $ZTS != enable ]]; then
+    sed -i -e '/--enable-maintainer-zts/d' $HOME/.php-build/share/php-build/default_configure_options
   fi
 - | # disable xdebug on master
   if [[ $VERSION = master && $RELEASE != xenial ]]; then

--- a/bin/archive
+++ b/bin/archive
@@ -12,15 +12,24 @@ if [[ ! $VERSION ]] ; then
   exit 1
 fi
 
+if [[ ! $ZTS ]] ; then
+  echo 'Missing $ZTS'
+  exit 1
+fi
+
 set -o xtrace
 
 : ${TAR_PATHS:=$HOME/.pearrc}
 : ${DESTS:=}
 
+if [[ $ZTS != enable ]] ; then
+  NTS="-nts"
+fi
+
 if [[ $VERSION =~ ^(php|hhvm) ]] ; then
-  DEST_VERSION="${VERSION}"
+  DEST_VERSION="${VERSION}${NTS}"
 else
-  DEST_VERSION="php-${VERSION}"
+  DEST_VERSION="php-${VERSION}${NTS}"
 fi
 
 TAR_PATHS="$TAR_PATHS $INSTALL_DEST/$VERSION"
@@ -28,9 +37,9 @@ DESTS="$TRAVIS_BUILD_DIR/$LSB_RELEASE/${DEST_VERSION}.tar.bz2"
 
 if [[ $ALIAS ]] ; then
   if [[ $ALIAS =~ ^php|hhvm ]] ; then
-    LONG_ALIAS="${ALIAS}"
+    LONG_ALIAS="${ALIAS}${NTS}"
   else
-    LONG_ALIAS="php-${ALIAS}"
+    LONG_ALIAS="php-${ALIAS}${NTS}"
   fi
   TAR_PATHS="$TAR_PATHS $INSTALL_DEST/$ALIAS"
   DESTS="$DESTS $TRAVIS_BUILD_DIR/$LSB_RELEASE/${LONG_ALIAS}.tar.bz2"


### PR DESCRIPTION
The current implementation only builds ZTS (Zend Thread Safety) builds of PHP. This PR adds support for also building NTS (Non Thread Safe) builds, complete with `-nts` suffix to differentiate them from the ZTS default builds.