### PR TITLE
Allow extension builds to fail on master

### DIFF
--- a/bin/compile-extension-amqp
+++ b/bin/compile-extension-amqp
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o xtrace
-set -o errexit
 source $(dirname $0)/compile-extensions-common
 
 travis_time_start

--- a/bin/compile-extension-apcu
+++ b/bin/compile-extension-apcu
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o xtrace
-set -o errexit
 source $(dirname $0)/compile-extensions-common
 
 travis_time_start

--- a/bin/compile-extension-memcache
+++ b/bin/compile-extension-memcache
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o xtrace
-set -o errexit
 source $(dirname $0)/compile-extensions-common
 
 travis_time_start

--- a/bin/compile-extension-memcached
+++ b/bin/compile-extension-memcached
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o xtrace
-set -o errexit
 source $(dirname $0)/compile-extensions-common
 
 travis_time_start

--- a/bin/compile-extension-mongo
+++ b/bin/compile-extension-mongo
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o xtrace
-set -o errexit
 source $(dirname $0)/compile-extensions-common
 
 travis_time_start

--- a/bin/compile-extension-mongodb
+++ b/bin/compile-extension-mongodb
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o xtrace
-set -o errexit
 source $(dirname $0)/compile-extensions-common
 
 travis_time_start

--- a/bin/compile-extension-redis
+++ b/bin/compile-extension-redis
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o xtrace
-set -o errexit
 source $(dirname $0)/compile-extensions-common
 
 travis_time_start

--- a/bin/compile-extension-ssh2
+++ b/bin/compile-extension-ssh2
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o xtrace
-set -o errexit
 source $(dirname $0)/compile-extensions-common
 
 travis_time_start

--- a/bin/compile-extension-zmq
+++ b/bin/compile-extension-zmq
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o xtrace
-set -o errexit
 source $(dirname $0)/compile-extensions-common
 
 travis_time_start

--- a/bin/compile-extensions-common
+++ b/bin/compile-extensions-common
@@ -4,6 +4,12 @@ set -o xtrace
 
 phpenv global $VERSION
 
+# Extensions are often not compatible with master, so attempt to build them,
+# but allow failures. For other branches we require extensions to build successfully.
+if [[ ! $VERSION =~ ^master$ ]]; then
+  set -o errexit
+fi
+
 travis_time_start() {
   travis_timer_id=$(printf %08x $(( RANDOM * RANDOM )))
   travis_start_time=$(travis_nanoseconds)


### PR DESCRIPTION
As PHP master introduces internal API changes, many extensions will not work with it, or don't have a released version that contains the necessary fixes. Most extensions only become compatible during the alpha or beta phase of a new release.

This PR tries to allow (my bash-foo is weak, I hope this does what I want it to do) extension builds to fail on the master branch. This means that extensions will only be available if they compile successfully against master.

A possibly better alternative would be to simply not build 3rd-party extensions at all for nightlies. At least it would be more predictable.