### PR TITLE
install pcov for 7.1 - 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,7 @@ script:
       ./bin/compile-extension-mongodb) &&
       ./bin/compile-extension-amqp &&
       ./bin/compile-extension-apcu &&
+      ./bin/compile-extension-pcov &&
       ./bin/compile-extension-zmq &&
       (./bin/compile-extension-memcache;
       ./bin/compile-extension-memcached) &&

--- a/bin/compile
+++ b/bin/compile
@@ -72,6 +72,10 @@ pdo_mysql.default_socket = /var/run/mysqld/mysqld.sock
 xdebug.max_nesting_level = 256
 EOF
 
+cat >> "${INSTALL_DEST}/${VERSION}/etc/conf.d/pcov.ini" <<EOF
+pcov.enabled=0
+EOF
+
 if [ $ALIAS ]; then
   ln -s ${INSTALL_DEST}/${VERSION} ${INSTALL_DEST}/${ALIAS}
 fi

--- a/bin/compile-extension-pcov
+++ b/bin/compile-extension-pcov
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -o xtrace
+set -o errexit
+source $(dirname $0)/compile-extensions-common
+
+travis_time_start
+
+if [[ $VERSION =~ ^7\.[1234] ]]; then
+	pecl_install pcov </dev/null
+else
+	echo "PHP $VERSION is not supported by PCOV"
+fi
+
+travis_time_finish


### PR DESCRIPTION
This installs pcov (a new code coverage driver) for 7.1 through 7.4, it is disabled by default so it doesn't interfere with jobs requiring Xdebug for coverage.