### PR TITLE
Fetch go-pear.phar from pear.php.net again

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,7 @@ php-build -i development "${VERSION}" "${INSTALL_DEST}/${VERSION}"
 pushd "${INSTALL_DEST}/${VERSION}"
 
 # pear
-curl -fsSL -O http://pear.php.net/go-pear.phar
+curl -fsSL --retry 20 -O http://pear.php.net/go-pear.phar
 
 env TZ=UTC $TRAVIS_BUILD_DIR/bin/install-pear
 rm go-pear.phar

--- a/bin/compile
+++ b/bin/compile
@@ -1,19 +1,5 @@
 #!/usr/bin/env bash
 
-function fetch_pear() {
-  if [ -n $GITHUB_TOKEN ]; then
-  	auth_flag="-H 'Authorization: token $GITHUB_TOKEN'"
-  fi
-
-  latest_tag=$(curl -sSfL --retry 20 "${auth_flag}" https://api.github.com/repos/pear/pearweb_phars/releases/latest | jq -r .tag_name)
-  curl -sSfL "${auth_flag}" --retry 20 -O https://raw.githubusercontent.com/pear/pearweb_phars/${latest_tag}/go-pear.phar
-
-  if [ ! -f go-pear.phar ]; then
-  	echo "Latest PEAR tarball not found"
-  	exit 1
-  fi
-}
-
 set -o errexit
 
 if [[ ! $VERSION ]] ; then
@@ -35,7 +21,7 @@ php-build -i development "${VERSION}" "${INSTALL_DEST}/${VERSION}"
 pushd "${INSTALL_DEST}/${VERSION}"
 
 # pear
-fetch_pear
+curl -fsSL -O http://pear.php.net/go-pear.phar
 
 env TZ=UTC $TRAVIS_BUILD_DIR/bin/install-pear
 rm go-pear.phar


### PR DESCRIPTION
pear.php.net is back online, so switch back to using it.