### PR TITLE
Add libsasl2.pc for Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ install:
 - popd
 - if [[ $RELEASE != precise ]]; then unset ICU_RELEASE; fi # disable ICU installation for Trusty; see https://github.com/travis-ci/travis-ci/issues/3616#issuecomment-286302387
 - | # older distros don't ship a libjpeg.pc, add our own to pkg-config path
-  if ! pkg-config --exists libjpeg; then
+  if ! pkg-config --exists libjpeg libsasl2; then
     export PKG_CONFIG_PATH=$PWD:$PKG_CONFIG_PATH
   fi
 - ./bin/install-icu

--- a/libsasl2.pc
+++ b/libsasl2.pc
@@ -1,0 +1,12 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${prefix}/lib/x86_64-linux-gnu
+includedir=${prefix}/include
+
+Name: Cyrus SASL
+Description: Cyrus SASL implementation
+URL: http://www.cyrussasl.org/
+Version: 2.1.25
+Cflags: -I${includedir}
+Libs: -L${libdir} -lsasl2
+Libs.private:  -ldl -lresolv  


### PR DESCRIPTION
libsasl2-dev on Trusty does not provide a pkgconfig file, so add our own.