### PR TITLE
Remove xmlrpc for master

### DIFF
--- a/default_configure_options.bionic-master
+++ b/default_configure_options.bionic-master
@@ -14,7 +14,6 @@
 --with-xsl
 --enable-ftp
 --with-tidy
---with-xmlrpc
 --enable-sysvsem
 --enable-sysvshm
 --enable-sysvmsg

--- a/default_configure_options.focal-master
+++ b/default_configure_options.focal-master
@@ -14,7 +14,6 @@
 --with-xsl
 --enable-ftp
 --with-tidy
---with-xmlrpc
 --enable-sysvsem
 --enable-sysvshm
 --enable-sysvmsg

--- a/default_configure_options.trusty-master
+++ b/default_configure_options.trusty-master
@@ -14,7 +14,6 @@
 --with-xsl
 --enable-ftp
 --with-tidy
---with-xmlrpc
 --enable-sysvsem
 --enable-sysvshm
 --enable-sysvmsg

--- a/default_configure_options.xenial-master
+++ b/default_configure_options.xenial-master
@@ -14,7 +14,6 @@
 --with-xsl
 --enable-ftp
 --with-tidy
---with-xmlrpc
 --enable-sysvsem
 --enable-sysvshm
 --enable-sysvmsg


### PR DESCRIPTION
The xmlrpc extension has been dropped from master, so drop the `--with-xmlrpc` switch from configure.