### PR TITLE
Fix master build, definition gone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -316,10 +316,6 @@ install:
     cp default_configure_options.$RELEASE $HOME/.php-build/share/php-build/default_configure_options
   fi
 - cat custom_configure_options >> $HOME/.php-build/share/php-build/default_configure_options
-- | # disable xdebug on master
-  if [[ $VERSION = master && $RELEASE != xenial ]]; then
-    sed -i -e '/install_xdebug_master/d' $HOME/.php-build/share/php-build/definitions/$VERSION
-  fi
 - |
   if [[ $(lsb_release -cs) = "trusty" || $(lsb_release -cs) = "xenial" || $(lsb_release -cs) = "bionic" ]]; then
     if [[ $HOSTTYPE == "powerpc64le" ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -60,7 +60,11 @@ set -o xtrace
 
 export PATH="$HOME/.phpenv/bin:$HOME/.php-build/bin:$PATH"
 
-php-build -i development "${VERSION}" "${INSTALL_DEST}/${VERSION}"
+if [[ $VERSION == nightly* || $VERSION == master* ]]; then
+    php-build -i development "${VERSION}"
+else
+    php-build -i development "${VERSION}" "${INSTALL_DEST}/${VERSION}"
+fi
 
 pushd "${INSTALL_DEST}/${VERSION}"
 


### PR DESCRIPTION
Not sure if this is the right way to fix it, but it seems master definition was deleted in this commit:
https://github.com/php-build/php-build/commit/03c6251b00288cf7531a2daabe4dab86c457a0a5

Relates to: https://travis-ci.community/t/update-php-nightly/9734/2