### PR TITLE
fix master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -316,10 +316,6 @@ install:
     cp default_configure_options.$RELEASE $HOME/.php-build/share/php-build/default_configure_options
   fi
 - cat custom_configure_options >> $HOME/.php-build/share/php-build/default_configure_options
-- | # disable xdebug on master
-  if [[ $VERSION = master && $RELEASE != xenial ]]; then
-    sed -i -e '/install_xdebug_master/d' $HOME/.php-build/share/php-build/definitions/$VERSION
-  fi
 - |
   if [[ $(lsb_release -cs) = "trusty" || $(lsb_release -cs) = "xenial" || $(lsb_release -cs) = "bionic" ]]; then
     if [[ $HOSTTYPE == "powerpc64le" ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -60,12 +60,11 @@ set -o xtrace
 
 export PATH="$HOME/.phpenv/bin:$HOME/.php-build/bin:$PATH"
 
-buildDefinition=${VERSION}
 if [[ $VERSION == nightly* || $VERSION == master* ]]; then
-    buildDefinition=8.0snapshot
+    VERSION=8.0snapshot
 fi
 
-php-build -i development "${buildDefinition}" "${INSTALL_DEST}/${VERSION}"
+php-build -i development "${VERSION}" "${INSTALL_DEST}/${VERSION}"
 
 pushd "${INSTALL_DEST}/${VERSION}"
 
@@ -88,7 +87,7 @@ ln -sv ../sbin/php-fpm bin/php-fpm
 
 # composer and phpunit
 curl -fsSL -o bin/composer http://getcomposer.org/composer.phar
-if [[ $VERSION == nightly* || $VERSION == master* || $VERSION == 7* ]]; then
+if [[ $VERSION == nightly* || $VERSION == master* || $VERSION == 7* || $VERSION == 8.0snapshot ]]; then
 	PHPUNIT_ARCHIVE=phpunit.phar
 elif [[ $VERSION == 5.6* ]]; then
 	PHPUNIT_ARCHIVE=phpunit-5.7.phar

--- a/bin/compile
+++ b/bin/compile
@@ -60,7 +60,12 @@ set -o xtrace
 
 export PATH="$HOME/.phpenv/bin:$HOME/.php-build/bin:$PATH"
 
-php-build -i development "${VERSION}" "${INSTALL_DEST}/${VERSION}"
+buildDefinition=${VERSION}
+if [[ $VERSION == nightly* || $VERSION == master* ]]; then
+    buildDefinition=8.0snapshot
+fi
+
+php-build -i development "${buildDefinition}" "${INSTALL_DEST}/${VERSION}"
 
 pushd "${INSTALL_DEST}/${VERSION}"
 


### PR DESCRIPTION
The master definition was removed on the 5.8, but 8.0snapshot was added that can be used.
The nightly master build is failing due to this since the removal.