### PR TITLE
fix version overwrite

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -60,11 +60,12 @@ set -o xtrace
 
 export PATH="$HOME/.phpenv/bin:$HOME/.php-build/bin:$PATH"
 
+buildDefinition=${VERSION}
 if [[ $VERSION == nightly* || $VERSION == master* ]]; then
-    VERSION=8.0snapshot
+    buildDefinition=8.0snapshot
 fi
 
-php-build -i development "${VERSION}" "${INSTALL_DEST}/${VERSION}"
+php-build -i development "${buildDefinition}" "${INSTALL_DEST}/${VERSION}"
 
 pushd "${INSTALL_DEST}/${VERSION}"
 


### PR DESCRIPTION
@BanzaiMan an issue with the version overwrite [was reported](https://github.com/travis-ci/php-src-builder/pull/53#issuecomment-687561652) which is causing builds with nightly to fail completely, so i am reverting back to just aliasing the build definition.
I think this is the nicer way, otherwise we have spread logic across the scripts. Also if we ever get the master definition back, we just need to revert those lines.
If you prefer another approach, let me know, thx man :v: 