### PR TITLE
Point nightly to 8.1*

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -62,11 +62,7 @@ export PATH="$HOME/.phpenv/bin:$HOME/.php-build/bin:$PATH"
 
 buildDefinition=${VERSION}
 if [[ $VERSION == nightly* || $VERSION == master* ]]; then
-  if [[ $RELEASE == jammy ]]; then
     buildDefinition=8.1snapshot
-  else
-    buildDefinition=8.0snapshot
-  fi
 fi
 
 php-build -i development "${buildDefinition}" "${INSTALL_DEST}/${VERSION}"


### PR DESCRIPTION
Currently `php: nightly` only points to the PHP8.0.* latest version. That should point to PHP8.1.*